### PR TITLE
Authentication

### DIFF
--- a/auth.yaml
+++ b/auth.yaml
@@ -6,5 +6,5 @@ api_keys:
       - time_window: 1s
         limit: 10
     allowed_hosts:
-      - rpc.ag
-      - localhost
+      - http://localhost:8080
+      - http://rpc.ag

--- a/auth.yaml
+++ b/auth.yaml
@@ -1,7 +1,7 @@
 api_keys:
   - key: 5cb686db33215c303fcc289e60eeffa2
     rate_limit:
-      - time_window: 30d
+      - time_window: 720h
         limit: 50000
       - time_window: 1s
         limit: 10

--- a/auth.yaml
+++ b/auth.yaml
@@ -1,0 +1,10 @@
+api_keys:
+  - key: 5cb686db33215c303fcc289e60eeffa2
+    rate_limit:
+      - time_window: 30d
+        limit: 50000
+      - time_window: 1s
+        limit: 10
+    allowed_hosts:
+      - rpc.ag
+      - localhost

--- a/cmd/rpc-proxy/main.go
+++ b/cmd/rpc-proxy/main.go
@@ -23,7 +23,7 @@ func main() {
 	var configFilePath string
 	flag.StringVar(&configFilePath, "config", "./config.yaml", "config file to load")
 	flag.Parse()
-	conf, err := config.Read(configFilePath)
+	conf, err := config.ReadConfig(configFilePath)
 	if err != nil {
 		logger.Panic("failed to load config", zap.Error(err))
 	}

--- a/cmd/rpc-proxy/main.go
+++ b/cmd/rpc-proxy/main.go
@@ -21,7 +21,9 @@ func main() {
 	defer logger.Sync()
 
 	var configFilePath string
+	var authFilePath string
 	flag.StringVar(&configFilePath, "config", "./config.yaml", "config file to load")
+	flag.StringVar(&authFilePath, "auth", "./auth.yaml", "auth file to load")
 	flag.Parse()
 	conf, err := config.ReadConfig(configFilePath)
 	if err != nil {
@@ -29,7 +31,13 @@ func main() {
 	}
 	logger.Info("config loaded", zap.Any("conf", conf))
 
-	server, err := webserver.New(conf, logger)
+	auth, err := config.ReadAuth(authFilePath)
+	if err != nil {
+		logger.Panic("failed to load auth", zap.Error(err))
+	}
+	logger.Info("auth loaded")
+
+	server, err := webserver.New(conf, auth, logger)
 	if err != nil {
 		logger.Panic("failed to start webserver", zap.Error(err))
 	}

--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ nodes:
     protocol: "https"
     weight: 1
     rate_limit:
-      - time_window: 30d
+      - time_window: 720h
         limit: 40000
       - time_window: 1s
         limit: 10

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -1,0 +1,26 @@
+package config
+
+import "github.com/spf13/viper"
+
+type Auth struct {
+	APIKeys []APIKeys `mapstructure:"api_keys"`
+}
+
+type APIKeys struct {
+	Key          string      `mapstructure:"key"`
+	RateLimit    []RateLimit `mapstructure:"rate_limit"`
+	AllowedHosts []string    `mapstructure:"allowed_hosts"`
+}
+
+func ReadAuth(file string) (*Auth, error) {
+	v := viper.New()
+	v.SetConfigFile(file)
+	if err := v.ReadInConfig(); err != nil {
+		return nil, err
+	}
+	var cfg Auth
+	if err := v.Unmarshal(&cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -3,13 +3,31 @@ package config
 import "github.com/spf13/viper"
 
 type Auth struct {
-	APIKeys []APIKeys `mapstructure:"api_keys"`
+	APIKeys []*APIKey `mapstructure:"api_keys"`
+
+	//
+	keys map[string]*APIKey
 }
 
-type APIKeys struct {
+func (a *Auth) reIndexKeys() {
+	a.keys = map[string]*APIKey{}
+	if len(a.APIKeys) > 0 {
+		for _, key := range a.APIKeys {
+			a.keys[key.Key] = key
+		}
+	}
+}
+
+func (a *Auth) Auth(key string) (apikey *APIKey, found bool) {
+	apiKey, found := a.keys[key]
+	return apiKey, found
+}
+
+type APIKey struct {
 	Key          string      `mapstructure:"key"`
 	RateLimit    []RateLimit `mapstructure:"rate_limit"`
 	AllowedHosts []string    `mapstructure:"allowed_hosts"`
+	//todo: create rate limiter instances here
 }
 
 func ReadAuth(file string) (*Auth, error) {
@@ -18,9 +36,10 @@ func ReadAuth(file string) (*Auth, error) {
 	if err := v.ReadInConfig(); err != nil {
 		return nil, err
 	}
-	var cfg Auth
-	if err := v.Unmarshal(&cfg); err != nil {
+	var auth Auth
+	if err := v.Unmarshal(&auth); err != nil {
 		return nil, err
 	}
-	return &cfg, nil
+	auth.reIndexKeys()
+	return &auth, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,15 +37,16 @@ type RateLimit struct {
 	Limit      uint64        `mapstructure:"limit"`
 }
 
-func Read(file string) (*Config, error) {
-	viper.SetConfigFile(file)
-	if err := viper.ReadInConfig(); err != nil {
+func ReadConfig(file string) (*Config, error) {
+	v := viper.New()
+	v.SetConfigFile(file)
+	if err := v.ReadInConfig(); err != nil {
 		return nil, err
 	}
 	var cfg Config
-	if err := viper.Unmarshal(&cfg); err != nil {
+	if err := v.Unmarshal(&cfg); err != nil {
 		return nil, err
 	}
-	cfg.LoadedFile = viper.ConfigFileUsed()
+	cfg.LoadedFile = v.ConfigFileUsed()
 	return &cfg, nil
 }

--- a/internal/webserver/cors.go
+++ b/internal/webserver/cors.go
@@ -1,0 +1,36 @@
+package webserver
+
+import (
+	"net/http"
+
+	"github.com/valyala/fasthttp"
+)
+
+func (s *WebServer) Cors(ctx *fasthttp.RequestCtx) {
+	//return 200 with headers
+	k := ctx.UserValue("api_key").(string)
+	if k == "" {
+		ctx.SetStatusCode(http.StatusForbidden)
+		ctx.Response.Header.Set("X-RCP-Error", "no api key in request")
+		return
+	}
+
+	key, found := s.auth.Auth(k)
+	if !found {
+		ctx.SetStatusCode(http.StatusForbidden)
+		ctx.Response.Header.Set("X-RCP-Error", "api key not found")
+		return
+	}
+
+	for _, host := range key.AllowedHosts {
+		if host == string(ctx.Request.Header.Peek("Origin")) {
+			ctx.SetStatusCode(http.StatusNoContent)
+			ctx.Response.Header.Set("Access-Control-Allow-Origin", host)
+			return
+		}
+	}
+
+	ctx.SetStatusCode(http.StatusForbidden)
+	ctx.Response.Header.Set("X-RCP-Error", "host not allowed")
+	return
+}

--- a/internal/webserver/serve.go
+++ b/internal/webserver/serve.go
@@ -1,0 +1,38 @@
+package webserver
+
+import (
+	"github.com/rpc-ag/rpc-proxy/pkg/proxy"
+	"github.com/valyala/fasthttp"
+	"go.uber.org/zap"
+)
+
+func (s *WebServer) Serve(ctx *fasthttp.RequestCtx) {
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	next := s.upstream.Balancer.Next("a")
+	if next == nil {
+		ctx.SetStatusCode(fasthttp.StatusBadGateway)
+		s.logger.Error("no health node")
+		return
+	}
+	node, ok := next.(*proxy.Node)
+
+	if !ok {
+		ctx.SetStatusCode(fasthttp.StatusBadGateway)
+		return
+	}
+
+	err := node.ServeHTTP(ctx)
+	if err != nil {
+		node.SetHealthy(false)
+
+		if err == fasthttp.ErrTimeout {
+			s.Serve(ctx) // just try again with a new node
+			return
+		}
+
+		ctx.SetStatusCode(fasthttp.StatusBadGateway)
+		s.logger.Error("failed serving", zap.Error(err))
+		node.SetHealthy(false)
+		return
+	}
+}

--- a/test.http
+++ b/test.http
@@ -1,0 +1,2 @@
+OPTIONS http://localhost:8080/5cb686db33215c303fcc289e60eeffa2
+Origin: http://localhost:8080


### PR DESCRIPTION
One of the important components of rpc proxy is authentication. We need to prevent abusing and fairly distribute the limit we get from providers.

- Api keys and their config must be loaded from a static file to prevent latency.
- Each api key must have their own limit in different time windows, like 250k per month but 10 per second etc.
- Each api key must have their own allowed domain to prevent them being used for a different domain (CORS)
- Immediately responses with rate limit error if they reached one of the time window limit.